### PR TITLE
feat: cookie string input, reconfigure/reauth flows, uev2.id.session fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Agent working files (not for repo)
+Agent-Files/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+.eggs/
+dist/
+build/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Custom Home Assistant integration to track live Uber Eats orders, including enti
 - Supports multiple accounts with unique names.
 - Time zone selection for accurate API calls.
 - Defaults to home address for location when no order.
+- **Reconfigure flow** — easily update cookies without deleting the integration.
+- **Reauthentication flow** — automatic prompts when session expires.
 
 ## Installation
 
@@ -36,21 +38,33 @@ Or use this button:
 3. Restart HA.
 4. Add via UI.
 
-## Getting UUID & SID
+## Getting the Cookie String
+
 1. Log into [www.ubereats.com](https://www.ubereats.com) in a web browser (e.g., Chrome).
 2. Open Developer Tools (F12 or right-click > Inspect).
-3. Go to the "Network" tab > "Search GetActiveOrdersV1".
-4. Find the "sid" cookie and copy its value (long string, e.g., starting with "QA.CAESEF...").
-5. Find the "_userUuid" cookie and copy its value (long string).
-Both required fields are stored in the same place under GetActiveOrdersV1 in the cookies section!
+3. Go to the **Network** tab.
+4. Refresh the page or navigate to any page on ubereats.com.
+5. Click on any request in the list (e.g., `getActiveOrdersV1` or any other).
+6. In the **Headers** tab, find **Request Headers**.
+7. Look for the **Cookie** header and copy the **entire value** (it's a long string).
 
 <img width="886" height="590" alt="image" src="https://github.com/user-attachments/assets/c37132cd-3b28-44f3-83a3-56ed85e290b7" />
 
+**That's it!** The integration will automatically extract the required `sid` and `uev2.id.session` values from the cookie string.
 
 ## Configuration
-- **SID and UUID**: From Uber Eats browser cookies (see above).
-- **Account Name**: Unique name (e.g., "Personal").
-- **Time Zone**: Select from dropdown (used for API).
+- **Account Name**: Unique name (e.g., "Personal", "Work").
+- **Time Zone**: Select from dropdown (must match your Home Assistant time zone).
+- **Cookie String**: Full cookie string copied from browser DevTools (see above).
+
+## Updating Cookies (When Session Expires)
+
+Sessions typically expire every 4-6 weeks. When this happens:
+
+1. Go to **Settings** > **Devices & Services** > **Uber Eats**.
+2. Click the 3-dot menu > **Reconfigure**.
+3. Paste your new cookie string.
+4. Done! Your automations and entities remain intact.
 
 ## Entities
 - binary_sensor.<account>_uber_eats_active_order
@@ -68,7 +82,7 @@ Both required fields are stored in the same place under GetActiveOrdersV1 in the
 - sensor.<account>_uber_eats_driver_location (cross street)
 
 ## Automation
-Please use the official bluepint to easily setup tts messages/updates from uber. 100% hasle free!
+Please use the official blueprint to easily setup TTS messages/updates from Uber. 100% hassle free!
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fzodyking%2FUber-Eats-Active-Order-Updates-TTS-Blueprint%2Fblob%2Fmain%2Fuber_eats_updates_tts.yaml)
 

--- a/custom_components/uber_eats/__init__.py
+++ b/custom_components/uber_eats/__init__.py
@@ -1,14 +1,16 @@
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import label_registry as lr
 
 from .coordinator import UberEatsCoordinator
-from .const import DOMAIN, CONF_SID, CONF_UUID, CONF_ACCOUNT_NAME, CONF_TIME_ZONE
+from .const import DOMAIN, CONF_SID, CONF_SESSION_ID, CONF_ACCOUNT_NAME, CONF_TIME_ZONE
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor", "binary_sensor"]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
@@ -16,11 +18,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         coordinator = UberEatsCoordinator(
             hass,
             entry.data[CONF_SID],
-            entry.data[CONF_UUID],
+            entry.data[CONF_SESSION_ID],
             entry.data[CONF_ACCOUNT_NAME],
             entry.data[CONF_TIME_ZONE]
         )
-        await coordinator.async_refresh()
+        # Use async_config_entry_first_refresh to properly handle auth errors
+        await coordinator.async_config_entry_first_refresh()
         hass.data[DOMAIN][entry.entry_id] = coordinator
 
         # Create Uber Eats label if it doesn't exist
@@ -35,9 +38,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         return True
+    except ConfigEntryAuthFailed:
+        raise  # Let HA handle reauth flow
     except Exception as e:
         _LOGGER.exception("Failed to setup Uber Eats integration: %s", e)
-        return False
+        raise ConfigEntryNotReady from e
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/uber_eats/const.py
+++ b/custom_components/uber_eats/const.py
@@ -1,8 +1,14 @@
 DOMAIN = "uber_eats"
-CONF_SID = "sid"
-CONF_UUID = "uuid"
+
+# User input field
+CONF_COOKIE = "cookie"
 CONF_ACCOUNT_NAME = "account_name"
 CONF_TIME_ZONE = "time_zone"
+
+# Internal storage keys (parsed from cookie)
+CONF_SID = "sid"
+CONF_SESSION_ID = "session_id"
+
 ENDPOINT = "https://www.ubereats.com/api/getActiveOrdersV1"
 HEADERS_TEMPLATE = {
     "Content-Type": "application/json",

--- a/custom_components/uber_eats/manifest.json
+++ b/custom_components/uber_eats/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": [],
   "codeowners": ["@zodyking"],
   "iot_class": "cloud_polling",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "config_flow": true,
   "integration_type": "service"
 }

--- a/custom_components/uber_eats/translations/en.json
+++ b/custom_components/uber_eats/translations/en.json
@@ -5,25 +5,50 @@
         "title": "Uber Eats",
         "description": "Connect your Uber Eats account.",
         "data": {
-          "sid": "SID",
-          "uuid": "UUID",
-          "account_name": "Account name",
-          "time_zone": "Time zone"
+          "account_name": "Account Name",
+          "time_zone": "Time Zone",
+          "cookie": "Cookie String"
         },
         "data_description": {
-          "sid": "Session ID from ubereats.com cookies. Must be at least 30 characters and start with \"QA.\"",
-          "uuid": "User UUID from cookies/headers. Must be at least 20 characters and include a dash \"-\".",
-          "account_name": "Just a nickname for this account (e.g., Personal, Work).",
-          "time_zone": "Must match Home Assistant’s time zone. Other selections will be rejected."
+          "account_name": "A nickname for this account (e.g., Personal, Work).",
+          "time_zone": "Must match Home Assistant's time zone.",
+          "cookie": "Full cookie string from ubereats.com. Open DevTools (F12) → Network tab → refresh page → click any request → copy 'Cookie' header value."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Uber Eats",
+        "description": "Update cookie for account: {account_name}",
+        "data": {
+          "cookie": "Cookie String"
+        },
+        "data_description": {
+          "cookie": "Full cookie string from ubereats.com. Open DevTools (F12) → Network tab → copy 'Cookie' header."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Session Expired",
+        "description": "Your Uber Eats session has expired for account: {account_name}. Please provide a fresh cookie.",
+        "data": {
+          "cookie": "Cookie String"
+        },
+        "data_description": {
+          "cookie": "Full cookie string from ubereats.com. Open DevTools (F12) → Network tab → copy 'Cookie' header."
         }
       }
     },
+    "abort": {
+      "reauth_successful": "Reauthentication successful.",
+      "reconfigure_successful": "Reconfiguration successful."
+    },
     "error": {
       "entry_too_short": "Entry too short.",
-      "must_include_dash": "Must include a dash \"-\".",
-      "must_start_with_qa": "Must start with \"QA.\"",
+      "cookie_too_short": "Cookie string is too short. Make sure you copied the entire cookie.",
+      "sid_not_found": "Could not find 'sid' in cookie string. Make sure you're logged in to ubereats.com.",
+      "invalid_sid": "Invalid SID format. The 'sid' cookie should start with 'QA.'",
+      "session_not_found": "Could not find 'uev2.id.session' in cookie string. Try refreshing ubereats.com and copying the cookie again.",
+      "invalid_session": "Invalid session format.",
       "invalid_time_zone": "Select your Home Assistant time zone.",
-      "invalid_credentials": "Unable to validate credentials. Check SID/UUID and try again.",
+      "invalid_credentials": "Unable to validate credentials. Cookie may be expired or invalid.",
       "unknown_error": "An unexpected error occurred. Check logs for details."
     }
   }


### PR DESCRIPTION
BREAKING CHANGE: Config flow now uses single cookie string input instead of separate SID/UUID fields.

- Replace _userUuid with uev2.id.session cookie (fixes auth issue)
- Add cookie string parsing - users just paste full cookie from DevTools
- Add reconfigure flow for easy credential updates
- Add reauthentication flow for expired sessions
- Add auth failure detection (401/403) in coordinator
- Update translations with new labels and error messages
- Bump version to 1.0.0

Closes #7